### PR TITLE
Usable Capacity for Snowball Edge Correction

### DIFF
--- a/doc_source/device-differences.md
+++ b/doc_source/device-differences.md
@@ -40,7 +40,7 @@ Each device has different storage capacities, as follows:
 | --- | --- | --- | 
 |  50 TB \(42 TB\) \- US regions only  | ✓ |  | 
 |  80 TB \(72 TB\)  | ✓ |  | 
-|  100 TB \(83 TB\)  |  | ✓ | 
+|  100 TB \(80 TB\)  |  | ✓ | 
 |  100 TB Clustered \(45 TB per node\)  |  | ✓ | 
 
 Each device has the following physical interfaces for management purposes:


### PR DESCRIPTION
Issue #, if available:* The Correct Usable Capacity of Snowball Edge Appliance.

*Description of changes:*

There is an ambiguity in the Usable Capacity of the Snowball Edge. This page says that the capacity is **83** TB but based on the official Snowball Edge FAQs and other articles, it is **80** TB: 

**Snowball Specification page:**

_Snowball Edge devices have up to 80 TB of usable space._

Reference:

https://docs.aws.amazon.com/snowball/latest/developer-guide/specifications.html#specs-storage-optimized


**Snowball FAQ:** 

_Q: What is the difference between the Snowball Edge Storage Optimized and Snowball Edge Compute Optimized options?

Snowball Edge Storage Optimized is the optimal choice if you need to securely and quickly transfer dozens of terabytes to petabytes of data to AWS. It is also a good fit for running general purpose analysis such as IoT data aggregation and transformation. It provides up to 80 TB of usable HDD storage._

Reference: 
https://aws.amazon.com/snowball/faqs/


**Here are the contradicting references that show the 83 TB Usability Capacity:**

https://docs.amazonaws.cn/en_us/snowball/latest/ug/AWSSnowball-ug.pdf
https://docs.aws.amazon.com/snowball/latest/ug/device-differences.html


**Note:** 
I actually raised a similar issue like this about 2 years ago. Quite disappointing that this issue still persists: 
 
https://github.com/awsdocs/aws-snowball-developer-guide/pull/1


*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
